### PR TITLE
Primitive launch argument handling, fixed color reset

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-  "MainColor": { "Red": 255, "Green": 75, "Blue": 75 },
+  "MainColor": { "Red": 255, "Green": 5, "Blue": 175 },
   "AccentColor": { "Red": 255, "Green": 255, "Blue": 255 }
 }


### PR DESCRIPTION
- Originally the launch arguments were handled with if statements, now it can do multiple args
- Text color was leaking into border box, hotfixed