### PR TITLE
docs(readme): update installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,16 @@ with custom config file
 
 Run `cargo install --git https://github.com/azur1s/octofetch`
 
-### Arch
-
-[AUR](https://aur.archlinux.org/packages/?O=0&K=octofetch) (Not by me, but usable)
-
-`yay -S octofetch` (the `octofetch` packages seems to get faster update than `octofetch-git`)
-
-### Github (requires Cargo)
+### Manual install with cargo
 
 1. Clone git repos: `git clone https://github.com/azur1s/octofetch`
 2. Change directory: `cd octofetch`
-3. Build binary `make build` or `cargo bulid`
+3. Build binary `make build` or `cargo build`
 4. Change directory to `./target/debug` and then run it!
+
+### Linux
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/octofetch.svg)](https://repology.org/project/octofetch/versions)
 
 # Features
 


### PR DESCRIPTION
- rename `Github (requires Cargo)` to `Manual install with cargo`
- fix typo `bulid` -> `build`
- remove AUR section and add Linux section
    - now contains a badge that automatically updates as your code is published to more repositories
    - for example, I published octofetch on nix and it can be seen there
    - clicking on the badge shows all packages and whether they are up to date